### PR TITLE
Procedurally resolve title of bookmarks bar

### DIFF
--- a/src/main.imba
+++ b/src/main.imba
@@ -38,7 +38,10 @@ def init
 	Frequencies = frequencies or {}
 
 	global.chrome.bookmarks.getTree! do(bookmarks)
-		const folder = api.bfs 'Bookmarks Bar', bookmarks
+		# Bookmarks Bar folder is guaranteed to be the first child of the bookmarks tree root
+		const bookmarkBarTitle = bookmarks[0].children[0].title
+
+		const folder = api.bfs bookmarkBarTitle, bookmarks
 		state.links = api.traverse folder
 		api.sort_links!
 		state.loaded = yes


### PR DESCRIPTION
# Description

## The bug:

**S2R**

1. Open this extension in a non-english Chrome, or in Brave
2. Try to find a bookmark

**Expected**
It finds my bookmark

**Observed**
The collection is empty

**Notes**
The lookup is done by title "Bookmarks Bar", which does not apply in all cases described.

## The fix

According to [this (arguably questionable) source](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/a_3s0Y6ibz8?pli=1), the Bookmarks bar is guaranteed to be the first tree node below the root, so you can resolve it as its first child.

# Author review

- [x] Code
- [x] Functionality
