### PR TITLE
Added toggle for mouse input on bookmarks, added <C-n> <C-p> navigation

### DIFF
--- a/src/components/app-bang.imba
+++ b/src/components/app-bang.imba
@@ -43,7 +43,7 @@ tag app-bang
 
 		unless $tips.show_more
 
-			<.bang .selected [c:$bang-c] @click=api.handle_bang>
+			<.bang .selected [c:$bang-c] @click.if(config.data.enable_mouse)=api.handle_bang>
 				css d:flex fld:row jc:space-between ai:center
 					px:16px py:11px rd:5px c:$text-c
 

--- a/src/components/app-link.imba
+++ b/src/components/app-link.imba
@@ -3,9 +3,9 @@ tag app-link
 	frequency = 0
 
 	<self
-		@contextmenu.trap=api.edit-link(link)
-		@pointerover=api.set_link_selection_index(index)
-		@click=api.handle_click_link
+		@contextmenu.trap.if(config.data.enable_mouse)=api.edit-link(link)
+		@pointerover.if(config.data.enable_mouse)=api.set_link_selection_index(index)
+		@click.if(config.data.enable_mouse)=api.handle_click_link
 		.selected=(index is state.link_selection_index)
 	>
 		css d:flex fld:row jc:space-between ai:center

--- a/src/components/app-links.imba
+++ b/src/components/app-links.imba
@@ -27,8 +27,8 @@ tag app-links
 		temp = {
 				click_handler: api.increment_link_selection_index.bind(api)
 				hotkey_handler: api.increment_link_selection_index.bind(api)
-				hotkey: 'down'
-				hotkey_display_name: "Down Arrow"
+				hotkey: 'down|ctrl+n'
+				hotkey_display_name: "Down Arrow / <C-n>"
 				content: "Move Selection Down"
 		}
 		result.push temp
@@ -36,8 +36,8 @@ tag app-links
 		temp = {
 				click_handler: api.decrement_link_selection_index.bind(api)
 				hotkey_handler: api.decrement_link_selection_index.bind(api)
-				hotkey: 'up'
-				hotkey_display_name: "Up Arrow"
+				hotkey: 'up|ctrl+p'
+				hotkey_display_name: "Up Arrow / <C-p>"
 				content: "Move Selection Up"
 		}
 		result.push temp

--- a/src/components/app-settings.imba
+++ b/src/components/app-settings.imba
@@ -50,3 +50,9 @@ tag app-settings
 
 			<button @click=config.toggle_case>
 				"CASE: {config.data.case.toUpperCase!}"
+
+
+		<.button-row>
+			<button @click=config.toggle_mouse>
+				"MOUSE INPUT: {config.data.enable_mouse}"
+

--- a/src/components/app-settings.imba
+++ b/src/components/app-settings.imba
@@ -51,8 +51,5 @@ tag app-settings
 			<button @click=config.toggle_case>
 				"CASE: {config.data.case.toUpperCase!}"
 
-
-		<.button-row>
 			<button @click=config.toggle_mouse>
 				"MOUSE INPUT: {config.data.enable_mouse}"
-

--- a/src/components/app-url.imba
+++ b/src/components/app-url.imba
@@ -31,7 +31,7 @@ tag app-url
 
 		<app-tips$tips tips=tips>
 
-		<.bang .selected @click=api.handle_url>
+		<.bang .selected @click.if(config.data.enable_mouse)=api.handle_url>
 			css d:flex fld:row jc:space-between ai:center
 				px:16px py:11px rd:5px c:blue6
 

--- a/src/config.imba
+++ b/src/config.imba
@@ -24,6 +24,7 @@ export default new class config
 		data.default_bang.name ??= ""
 		data.default_bang.url ??= "https://www.google.com/search?q=$0"
 		data.default_bang.frequency ??= 0
+		data.enable_mouse ??= yes
 		save!
 
 	def cycle_theme
@@ -79,6 +80,11 @@ export default new class config
 		else
 			data.case = "lowercase"
 		save!
+
+	def toggle_mouse
+		data.enable_mouse = !data.enable_mouse
+		save!
+
 
 	get theme
 		if data.theme is "light"


### PR DESCRIPTION
Feature: Add Mouse input toggle and Ctrl+N/P navigation
- Added Ctrl+N as alternative to Down Arrow for moving selection down
- Added Ctrl+P as alternative to Up Arrow for moving selection up
- Added mouse input toggle in settings
- If disabled, mouse movement will not affect selected bookmark

Changes:
1. Modified app-links.imba to add Ctrl+N/P navigation
2. Added enable_mouse toggle to config
3. Added mouse input toggle button to settings
4. Added conditional mouse event handlers based on enable_mouse setting

Notes:
Not sure why but recently when i build and run the extension locally when i try and enter into the first link and my cursor is on any of the other links it will go to that instead. Does not happen when using the extension store version ;/ 