### PR TITLE
feat: Bypass active bookmark hotkey

### DIFF
--- a/src/components/app-links.imba
+++ b/src/components/app-links.imba
@@ -14,6 +14,12 @@ tag app-links
 		result.push temp
 
 		temp = {
+			hotkey_handler: api.handle_bang.bind(api)
+			hotkey: config.data.hotkey.force_bang
+			}
+		result.push temp
+
+		temp = {
 				click_handler: api.handle_cut.bind(api)
 				hotkey_display_name: "Cut"
 				content: "Cut All Text"

--- a/src/config.imba
+++ b/src/config.imba
@@ -35,6 +35,7 @@ export default new class config
 		data.hotkey.handle_bang ??= 'return'
 		data.hotkey.handle_url ??= 'return'
 		data.hotkey.handle_click_link ??= 'return'
+		data.hotkey.force_bang ??= 'shift+return'
 		data.hotkey.unset_active_bang ??= 'esc'
 		data.hotkey.increment_link_selection_index ??= 'down'
 		data.hotkey.decrement_link_selection_index ??= 'up'


### PR DESCRIPTION
Changes:
Added `force_bang` hotkey configuration (default: shift+return) to skip the selected bookmark and use the default search bang

Helps when you have a short query that matches an existing bookmark, which prevents using the search bang.